### PR TITLE
DUBOPS-5274 Change list and search modules API to return unique modules.

### DIFF
--- a/routes/list.js
+++ b/routes/list.js
@@ -20,7 +20,7 @@ router.get('/search', async (req, res) => {
     ...req.query,
     selector: {
       name: {
-        $regex: new RegExp(req.query.q),
+        $regex: req.query.q,
       },
     },
     q: null,

--- a/stores/mongodb.js
+++ b/stores/mongodb.js
@@ -27,7 +27,6 @@ const saveModule = (data) => {
 const findModules = (options) => Module.find(options);
 
 const findAllModules = (options, meta, offset, limit) => {
-  debug('search store with %o', options);
   group = {
     "$group": {
       _id: {
@@ -48,9 +47,15 @@ const findAllModules = (options, meta, offset, limit) => {
     }
   }
   if (options.namespace) {
-    match = {$match: {namespace: options.namespace}}
+    match = {
+      "$match": {
+        namespace: options.namespace
+      }
+    }
   }
-  console.log(group)
+  debug('search store with %o', options);
+  debug('group documents with %o', group);
+  debug('match documents with %o', match);
   return Module.aggregate([group, match, {$sort: { published_at: -1}}, {$skip: offset}, {$limit: limit}])
     .then((docs) => {
       debug('search result from store: %o', docs);

--- a/stores/mongodb.js
+++ b/stores/mongodb.js
@@ -28,15 +28,37 @@ const findModules = (options) => Module.find(options);
 
 const findAllModules = (options, meta, offset, limit) => {
   debug('search store with %o', options);
-
-  return Module.find(options, null, { sort: '_id', skip: offset, limit })
+  group = {
+    "$group": {
+      _id: {
+        namespace: "$namespace",
+        name: "$name"
+      },
+      id: { "$first": "$id" },
+      owner: { "$first": "$owner"},
+      namespace : { "$first": "$namespace"},
+      name: { "$first": "$name"},
+      version: { "$first": "$version"},
+      provider: { "$first": "$provider"},
+      description: { "$first": "$description"},
+      source: { "$first": "$source"},
+      published_at: { "$first": "$published_at"},
+      downloads: { "$first": "$downloads"},
+      verified: { "$first": "$verified"}
+    }
+  }
+  if (options.namespace) {
+    match = {$match: {namespace: options.namespace}}
+  }
+  console.log(group)
+  return Module.aggregate([group, match, {$sort: { published_at: -1}}, {$skip: offset}, {$limit: limit}])
     .then((docs) => {
       debug('search result from store: %o', docs);
       return {
         meta,
         modules: docs,
       };
-    });
+  });
 };
 
 const getModuleVersions = (options) => {

--- a/stores/mongodb.js
+++ b/stores/mongodb.js
@@ -27,7 +27,7 @@ const saveModule = (data) => {
 const findModules = (options) => Module.find(options);
 
 const findAllModules = (options, meta, offset, limit) => {
-  group = {
+  grouping = {
     "$group": {
       _id: {
         namespace: "$namespace",
@@ -46,17 +46,16 @@ const findAllModules = (options, meta, offset, limit) => {
       verified: { "$first": "$verified"}
     }
   }
-  if (options.namespace) {
-    match = {
-      "$match": {
-        namespace: options.namespace
-      }
+  params = [grouping, {$sort: { published_at: -1}}, {$skip: offset}, {$limit: limit}]
+  if (Object.keys(options).length != 0) {
+    match = {"$match": {}}
+    for (const property in options) {
+      match.$match[property] = options[property]
     }
+    params.push(match)
   }
-  debug('search store with %o', options);
-  debug('group documents with %o', group);
-  debug('match documents with %o', match);
-  return Module.aggregate([group, match, {$sort: { published_at: -1}}, {$skip: offset}, {$limit: limit}])
+  debug('search store with %o', params);
+  return Module.aggregate(params)
     .then((docs) => {
       debug('search result from store: %o', docs);
       return {


### PR DESCRIPTION
Rather than returning a list of module versions this changes the API to return a list of unique modules.

It uses the MongoDB aggregate functionality to create a unique namespace + name grouping and returns the first module found for each unique grouping.

This better matches the intended behaviour of the API calls based on the Terraform registry API docs and when compared with how the public Terraform registry acts.

This only changes the behaviour for mongodb backed versions of Citizen.