### PR TITLE
DUBOPS-5274 use unshift instead of push

### DIFF
--- a/stores/mongodb.js
+++ b/stores/mongodb.js
@@ -46,13 +46,13 @@ const findAllModules = (options, meta, offset, limit) => {
       verified: { "$first": "$verified"}
     }
   }
-  params = [grouping, {$sort: { published_at: -1}}, {$skip: offset}, {$limit: limit}]
+  params = [grouping, {$sort: { published_at: -1}}, {$limit: limit}, {$skip: offset}]
   if (Object.keys(options).length != 0) {
     match = {"$match": {}}
     for (const property in options) {
       match.$match[property] = options[property]
     }
-    params.push(match)
+    params.unshift(match)
   }
   debug('search store with %o', params);
   return Module.aggregate(params)


### PR DESCRIPTION
Using push adds the match to the end of the array which means the group happens first, we want the match to happen first as otherwise the API can return a 404 at low limit/offset values but would return a 200 if the limit/offset values were higher.