### PR TITLE
Fix most recently published module not always appearing first when searched or listed 

### DIFF
--- a/stores/mongodb.js
+++ b/stores/mongodb.js
@@ -48,7 +48,7 @@ const findAllModules = (options, meta, offset, limit) => {
       verified: { "$first": "$verified"}
     }
   }
-  params = [grouping, {$sort: { published_at: -1}}, {$skip: offset}, {$limit: limit}]
+  params = [{$sort: { published_at: -1}}, grouping, {$skip: offset}, {$limit: limit}]
   if (Object.keys(options).length != 0) {
     match = {"$match": {}}
     for (const property in options) {


### PR DESCRIPTION
This was happening because we were running the sort after the grouping, so essentially sorting the list of modules after it had already been whittled down to one, which means the module version returned was essentially random, rather than the most recently published one.

Doing the sort before the grouping means that the most recent module version will be at the top of the list, and so the grouping uses that one (as it uses $first).